### PR TITLE
Xfer improvements

### DIFF
--- a/auth.c
+++ b/auth.c
@@ -138,7 +138,7 @@ fail:
 		"WWW-Authenticate", hdr,
 		UWSD_HTTP_REPLY_EOH);
 
-	uwsd_http_reply_send(cl, true);
+	uwsd_http_reply_send(cl, HTTP_WANT_CLOSE);
 
 	free(dec);
 	free(hdr);
@@ -182,7 +182,7 @@ fail:
 		"Peer certificate refused\n",
 		UWSD_HTTP_REPLY_EOH);
 
-	uwsd_http_reply_send(cl, true);
+	uwsd_http_reply_send(cl, HTTP_WANT_CLOSE);
 
 	return false;
 }

--- a/client.c
+++ b/client.c
@@ -52,6 +52,9 @@ client_create(int fd, uwsd_listen_t *listen, struct sockaddr *peeraddr, size_t a
 	cl->downstream.ufd.fd = fd;
 	cl->upstream.ufd.fd = -1;
 
+	cl->http.pipebuf[0] = -1;
+	cl->http.pipebuf[1] = -1;
+
 	memcpy(&cl->sa_peer.unspec, peeraddr, alen);
 
 	list_add_tail(&cl->list, &clients);
@@ -102,6 +105,12 @@ client_free(uwsd_client_context_t *cl, const char *reason, ...)
 
 	if (cl->downstream.ufd.fd != -1)
 		close(cl->downstream.ufd.fd);
+
+	if (cl->http.pipebuf[0] != -1)
+		close(cl->http.pipebuf[0]);
+
+	if (cl->http.pipebuf[1] != -1)
+		close(cl->http.pipebuf[1]);
 
 	while (cl->http_num_headers > 0)
 		free(cl->http_headers[--cl->http_num_headers].name);

--- a/config.c
+++ b/config.c
@@ -654,8 +654,8 @@ config_parse_value(const char **input, const config_prop_t *prop, void *base)
 			"false", "\0", "no", "\0", "off", "\0", "disabled", "\0",
 			NULL, NULL
 		}; *l; l += 2) {
-			if (!strcmp(p, *l)) {
-				e = *l;
+			if (!strcmp(p, l[0])) {
+				e = l[1];
 				break;
 			}
 		}

--- a/config.c
+++ b/config.c
@@ -439,7 +439,7 @@ static char
 hex(char c)
 {
 	if ((c|32) >= 'a')
-		return (c|32) - 'a';
+		return 10 + (c|32) - 'a';
 
 	return c - '0';
 }

--- a/example/paste-client.html
+++ b/example/paste-client.html
@@ -151,14 +151,18 @@
 					<div class="file ${isNew ? 'new' : ''}">
 						${
 							item.mimetype?.indexOf?.('image/') == 0
-								? `<img src="${attrescape(`${API_BASE_URI}/${item.url}`)}" onclick="openFile('${attrescape(`${API_BASE_URI}/${item.url}`)}')">`
-								: `<div class="thumbnail" onclick="openFile('${attrescape(`${API_BASE_URI}/${item.url}`)}')"><iframe src="${attrescape(`${API_BASE_URI}/${item.url}`)}" frameborder="0"></iframe></div>`
+								? `<img src="${attrescape(`${API_BASE_URI}${item.url}`)}" onclick="openFile('${attrescape(`${API_BASE_URI}${item.url}`)}')">`
+								: `<div class="thumbnail" onclick="openFile('${attrescape(`${API_BASE_URI}/${item.url}`)}')"><iframe src="${attrescape(`${API_BASE_URI}${item.url}`)}" frameborder="0"></iframe></div>`
 						}
 					</div>
 					<div class="metadata">
 						<div>
 							<span>Uploaded:</span>
 							<span>${(new Date(item.uploaded * 1000)).toLocaleString('en-US')}</span>
+						</div>
+						<div>
+							<span>Size:</span>
+							<span>${(+item.filesize/1024).toFixed(1)} KB</span>
 						</div>
 						<div>
 							<span>Transfer duration:</span>
@@ -185,7 +189,7 @@
 
 			function deleteFile(item) {
 				if (confirm(`Do you really want to delete the file "${item.name}"?`))
-					fetch(`${API_BASE_URI}/${item.url}`, { method: 'DELETE' }).then(() => listFiles());
+					fetch(`${API_BASE_URI}${item.url}`, { method: 'DELETE' }).then(() => listFiles());
 			}
 
 			function listFiles(newItem) {
@@ -213,7 +217,7 @@
 
 				body.append('upload', file);
 
-				fetch(`${API_BASE_URI}/upload`, { method: 'POST', body })
+				fetch(`${API_BASE_URI}/upload/${file.name}`, { method: 'PUT', body: file })
 					.then(response => {
 						if (!response.ok)
 							return response.text().then(error => Promise.reject(error));

--- a/http.c
+++ b/http.c
@@ -1359,6 +1359,8 @@ http_file_serve(uwsd_client_context_t *cl)
 	struct stat s;
 	int rv = 0;
 
+	uwsd_state_transition(cl, STATE_CONN_RESPONSE);
+
 	if (cl->request_method != HTTP_GET && cl->request_method != HTTP_HEAD)
 		uwsd_http_error_return(cl, 405, "Method Not Allowed",
 			"The used HTTP method is invalid for the requested resource\n");
@@ -1449,6 +1451,8 @@ http_directory_serve(uwsd_client_context_t *cl)
 	char *path = NULL, *url = NULL, *p;
 	struct stat s;
 	int rv = 0;
+
+	uwsd_state_transition(cl, STATE_CONN_RESPONSE);
 
 	if (cl->request_method != HTTP_GET && cl->request_method != HTTP_HEAD)
 		uwsd_http_error_return(cl, 405, "Method Not Allowed",

--- a/http.c
+++ b/http.c
@@ -306,7 +306,7 @@ http_determine_message_length(uwsd_client_context_t *cl, bool request)
 	tenc = uwsd_http_header_lookup(cl, "Transfer-Encoding");
 	clen = uwsd_http_header_lookup(cl, "Content-Length");
 
-	if (cl->http_version <= 0x1000 || uwsd_http_header_contains(cl, "Connection", "close"))
+	if (cl->http_version <= 0x0100 || uwsd_http_header_contains(cl, "Connection", "close"))
 		*flags |= HTTP_WANT_CLOSE;
 
 	if (tenc) {
@@ -330,8 +330,8 @@ http_determine_message_length(uwsd_client_context_t *cl, bool request)
 		cl->request_length = hlen;
 		http_state_transition(cl, STATE_HTTP_BODY_KNOWN_LENGTH);
 	}
-	else if (cl->http_version <= 0x1000 && cl->request_method == HTTP_POST) {
-		uwsd_http_error_return(cl, 400, "Bad Request", "Content-Length required\n");
+	else if (cl->http_version <= 0x0100 && cl->request_method == HTTP_POST) {
+		uwsd_http_error_return(cl, 411, "Length Required", "Content-Length required\n");
 	}
 	else if ((!request && http_may_have_body(cl->http_status)) &&
 	         (cl->http_version <= 0x0100 || cl->action->type == UWSD_ACTION_SCRIPT)) {

--- a/http.c
+++ b/http.c
@@ -1780,7 +1780,7 @@ uwsd_http_state_upstream_connected(uwsd_client_context_t *cl, uwsd_connection_st
 	size_t i;
 
 	if (cl->action->type == UWSD_ACTION_SCRIPT) {
-		if (!uwsd_script_request(cl, -1))
+		if (!uwsd_script_request(cl))
 			return; /* failure */
 	}
 	else if (cl->action->type == UWSD_ACTION_TCP_PROXY) {

--- a/include/client.h
+++ b/include/client.h
@@ -73,6 +73,8 @@ typedef struct uwsd_client_context {
 		uwsd_http_state_t state;
 		uint32_t request_flags;
 		uint32_t response_flags;
+		int pipebuf[2];
+		size_t pipebuf_len;
 	} http;
 	struct {
 		uwsd_ws_state_t state;

--- a/include/file.h
+++ b/include/file.h
@@ -38,6 +38,6 @@ __hidden bool uwsd_file_if_none_match(uwsd_client_context_t *, struct stat *);
 __hidden bool uwsd_file_if_range(uwsd_client_context_t *, struct stat *);
 __hidden bool uwsd_file_if_unmodified_since(uwsd_client_context_t *, struct stat *);
 
-__hidden bool uwsd_file_directory_list(uwsd_client_context_t *, const char *, const char *);
+__hidden int uwsd_file_directory_list(uwsd_client_context_t *, const char *, const char *);
 
 #endif /* UWSD_FILE_H */

--- a/include/http.h
+++ b/include/http.h
@@ -116,7 +116,7 @@ uwsd_http_reply_buffer(void *buf, size_t buflen, double http_version,
 			##__VA_ARGS__,												\
 			"Connection", "close", UWSD_HTTP_REPLY_EOH);				\
 																		\
-		if (uwsd_http_reply_send(cl, true))								\
+		if (uwsd_http_reply_send(cl, HTTP_WANT_CLOSE))					\
 			client_free(cl, "%hu (%s)", code, reason ? reason : "-");	\
 	} while(0)
 
@@ -130,7 +130,7 @@ uwsd_http_reply_buffer(void *buf, size_t buflen, double http_version,
 __hidden char *uwsd_http_header_lookup(uwsd_client_context_t *, const char *);
 __hidden bool uwsd_http_header_contains(uwsd_client_context_t *, const char *, const char *);
 
-__hidden bool uwsd_http_reply_send(uwsd_client_context_t *, bool);
+__hidden bool uwsd_http_reply_send(uwsd_client_context_t *, uint32_t);
 
 __hidden void uwsd_http_state_idle_timeout(uwsd_client_context_t *, uwsd_connection_state_t, bool);
 

--- a/include/io.h
+++ b/include/io.h
@@ -23,6 +23,7 @@
 #include <sys/uio.h>
 
 #include "util.h"
+#include "client.h"
 
 #define uwsd_iov_put(cl, ...) _uwsd_iov_put(cl, ##__VA_ARGS__, NULL)
 

--- a/include/script.h
+++ b/include/script.h
@@ -32,7 +32,7 @@ __hidden bool uwsd_script_send(uwsd_client_context_t *, const void *, size_t);
 __hidden void uwsd_script_close(uwsd_client_context_t *);
 __hidden void uwsd_script_free(uwsd_action_t *);
 
-__hidden bool uwsd_script_request(uwsd_client_context_t *, int);
+__hidden bool uwsd_script_request(uwsd_client_context_t *);
 __hidden bool uwsd_script_bodydata(uwsd_client_context_t *, const void *, size_t);
 
 #endif /* UWSD_SCRIPT_H */

--- a/script.c
+++ b/script.c
@@ -2197,7 +2197,7 @@ uwsd_script_free(uwsd_action_t *action)
 }
 
 __hidden bool
-uwsd_script_request(uwsd_client_context_t *cl, int downstream)
+uwsd_script_request(uwsd_client_context_t *cl)
 {
 	uint16_t tv[cl->http_num_headers], lv[cl->http_num_headers];
 	struct iovec iov[(7 + cl->http_num_headers) * 3];

--- a/util.c
+++ b/util.c
@@ -167,11 +167,8 @@ htmlescape(const char *str)
 
 	copy = calloc(1, len);
 
-	if (!copy) {
-		errno = ENOMEM;
-
+	if (!copy)
 		return NULL;
-	}
 
 	for (i = 0, p = copy; str[i]; i++)
 		if (is_html_special_char(str[i]))


### PR DESCRIPTION

1. **Paste Server Example Improvements** (`dd34def`)
   - Refactored the paste server example to use new script API capabilities:
     - Utilized `uwsd.uuid()` for generating unique file IDs.
     - Employed `request.store()` to handle uploads via file descriptors.
     - Leveraged `request.reply(..., fd)` to send back file data.

2. **HTTP Backend Data Transfer** (`97f5aea`)
   - Extended the HTTP frontend to use the `splice(2)` syscall with an intermediate buffer pipe for efficient backend data transfer.
   - Applied the splice-based fast path for non-SSL connections and predetermined length responses.

3. **Client Context Structure Update** (`79ebff2`)
   - Added an intermediate transfer pipe to the `uwsd_client_context_t` structure.
   - Included corresponding cleanup logic for future `splice(2)` refactoring.

4. **`request.reply()` Enhancement** (`2c29960`)
   - Extended `request.reply()` to accept file descriptor values, simplifying the process of sending file or pipe-backed data in HTTP replies.

5. **`request.store()` Implementation** (`2a4c53f`)
   - Introduced the `request.store()` method for HTTP request script callbacks to handle large amounts of request data by redirecting it into a specified file descriptor.

6. **Unused Argument Removal** (`eb4ed72`)
   - Removed the unused `downstream` argument from the `uwsd_script_request()` function signature and call sites.

7. **`uwsd.uuid()` Function Addition** (`d0214c5`)
   - Implemented the `uwsd.uuid()` function to generate UUID values, with optional seeding for consistent UUID generation.

8. **Hex Function Fix** (`7be798f`)
   - Fixed the `hex()` function to return correct numerical values for hexadecimal digits `A` to `F`.