### PR TITLE
script: fix compile error on linux

### DIFF
--- a/script.c
+++ b/script.c
@@ -24,6 +24,7 @@
 #include <signal.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <libgen.h>
 
 #include <arpa/inet.h>
 #include <sys/wait.h>


### PR DESCRIPTION
we need libgen.h for basename function. Otherwise:
```
error: implicit declaration of function 'basename'; did you mean 'rename'? [-Wimplicit-function-declaration]
 2067 |                                 basename(action->data.script.path),
      |                                 ^~~~~~~~
      |                                 rename
```