### PR TITLE
ssl-mbedtls: update to mbedtls 3

### DIFF
--- a/io.c
+++ b/io.c
@@ -51,7 +51,7 @@ uwsd_iov_send(uwsd_connection_t *conn, struct iovec *iov, size_t len)
 		return false;
 	}
 
-	for (i = 0; i < len; i++) {
+	for (i = 0; i < len && wlen > 0; i++) {
 		if ((size_t)wlen > iov[i].iov_len) {
 			wlen -= iov[i].iov_len;
 			iov[i].iov_base += iov[i].iov_len;
@@ -60,6 +60,7 @@ uwsd_iov_send(uwsd_connection_t *conn, struct iovec *iov, size_t len)
 		else {
 			iov[i].iov_base += wlen;
 			iov[i].iov_len -= wlen;
+			wlen = 0;
 
 			if (iov[i].iov_len)
 				return false;


### PR DESCRIPTION
mbedtls 3 requires an entropy pool and a drbg passed to mbedtls_pk_parse_keyfile which cannot be NULL.

Also, v3 blinds ext_types as MBEDTLS_PRIVATE, so we need to test for subject_alt_names.next != NULL

Otherwise it results in a compile error:
```
/home/build/openwrt/build_dir/target-x86_64_musl/uwsd-mbedtls/uwsd-2025.05.20~f98f3f1b/ssl-mbedtls.c:417:24: error: 'mbedtls_x509_crt' has no member named 'ext_types'
  417 |                 if (crt->ext_types & MBEDTLS_X509_EXT_SUBJECT_ALT_NAME) {
      |                        ^~
/home/build/openwrt/build_dir/target-x86_64_musl/uwsd-mbedtls/uwsd-2025.05.20~f98f3f1b/ssl-mbedtls.c:434:24: error: 'mbedtls_x509_crt' has no member named 'ext_types'
  434 |                 if (crt->ext_types & MBEDTLS_X509_EXT_SUBJECT_ALT_NAME) {
      |                        ^~
/home/build/openwrt/build_dir/target-x86_64_musl/uwsd-mbedtls/uwsd-2025.05.20~f98f3f1b/ssl-mbedtls.c: In function 'ssl_load_pem_files':
/home/build/openwrt/build_dir/target-x86_64_musl/uwsd-mbedtls/uwsd-2025.05.20~f98f3f1b/ssl-mbedtls.c:490:15: error: too few arguments to function 'mbedtls_pk_parse_keyfile'
  490 |         err = mbedtls_pk_parse_keyfile(&ssl_ctx->key, pkey_path, NULL);
      |               ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/build/openwrt/staging_dir/target-x86_64_musl/usr/include/mbedtls/ssl_ciphersuites.h:16,
                 from /home/build/openwrt/staging_dir/target-x86_64_musl/usr/include/mbedtls/ssl.h:20,
                 from /home/build/openwrt/build_dir/target-x86_64_musl/uwsd-mbedtls/uwsd-2025.05.20~f98f3f1b/ssl-mbedtls.c:29:
/home/build/openwrt/staging_dir/target-x86_64_musl/usr/include/mbedtls/pk.h:1174:5: note: declared here
 1174 | int mbedtls_pk_parse_keyfile(mbedtls_pk_context *ctx,
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
```

See e.g. https://sourcevu.sysprogs.com/espressif/lib/mbedtls/symbols/mbedtls_pk_parse_keyfile